### PR TITLE
refactor(approvals): Refactor approvals to be a state of a transaction

### DIFF
--- a/reference/openapi.yaml
+++ b/reference/openapi.yaml
@@ -137,6 +137,12 @@ paths:
     post:
       $ref: "./paths/transactions__async-create-transaction.yaml"
 
+  "/async/transactions/{transaction_id}/authorize":
+    parameters:
+      - $ref: "./path-parameters/transaction_id.yaml"
+    post:
+      $ref: "./paths/transactions__async-authorize-transaction.yaml"
+
   "/async/transactions/{transaction_id}/capture":
     parameters:
       - $ref: "./path-parameters/transaction_id.yaml"
@@ -219,11 +225,11 @@ paths:
     get:
       $ref: "./paths/payment_methods__approve-payment-method.yaml"
 
-  "/payment-methods/{payment_method_id}/confirm":
+  "/payment-method-approvals/{payment_method_approval_token}":
     parameters:
-      - $ref: "./path-parameters/payment_method_id.yaml"
+      - $ref: "./path-parameters/payment_method_approval_token.yaml"
     get:
-      $ref: "./paths/payment_methods__confirm-payment-method.yaml"
+      $ref: "./paths/payment_methods__redirect-payment-method-approval.yaml"
 
   "/payment-options":
     get:
@@ -289,6 +295,12 @@ paths:
     post:
       $ref: "./paths/transactions__capture-transaction.yaml"
 
+  "/transactions/{transaction_id}/authorize":
+    parameters:
+      - $ref: "./path-parameters/transaction_id.yaml"
+    post:
+      $ref: "./paths/transactions__authorize-transaction.yaml"
+
   "/transactions/{transaction_id}/refund":
     parameters:
       - $ref: "./path-parameters/transaction_id.yaml"
@@ -300,6 +312,18 @@ paths:
       - $ref: "./path-parameters/transaction_id.yaml"
     get:
       $ref: "./paths/transactions__list-transaction-events.yaml"
+
+  "/transactions/{transaction_id}/approve":
+    parameters:
+      - $ref: "./path-parameters/transaction_id.yaml"
+    get:
+      $ref: "./paths/transactions__approve-transaction.yaml"
+
+  "/transaction-approvals/{transaction_approval_token}":
+    parameters:
+      - $ref: "./path-parameters/transaction_approval_token.yaml"
+    get:
+      $ref: "./paths/transactions__redirect-transaction-approval.yaml"
 
   "/users/me":
     get:

--- a/reference/path-parameters/payment_method_approval_token.yaml
+++ b/reference/path-parameters/payment_method_approval_token.yaml
@@ -1,0 +1,11 @@
+---
+schema:
+  type: string
+  example: NDY5NzNlOWQtODhhNy00NGE2LWFiZmUtYmU0ZmYwMTM0ZmY0
+name: payment_method_approval_token
+in: path
+required: true
+description: |-
+  The token used to redirect the buyer for approval of the payment method setup.
+  This token does not represent anything to the consumer and no value should be
+  derived from it except for internal use.

--- a/reference/path-parameters/transaction_approval_token.yaml
+++ b/reference/path-parameters/transaction_approval_token.yaml
@@ -1,0 +1,11 @@
+---
+schema:
+  type: string
+  example: NDY5NzNlOWQtODhhNy00NGE2LWFiZmUtYmU0ZmYwMTM0ZmY0
+name: transaction_approval_token
+in: path
+required: true
+description: |-
+  The token used to redirect the buyer for approval of a transaction. This token
+  does not represent anything to the consumer and no value should be derived
+  from it except for internal use.

--- a/reference/paths/payment_methods__approve-payment-method.yaml
+++ b/reference/paths/payment_methods__approve-payment-method.yaml
@@ -1,31 +1,44 @@
 ---
 operationId: approve-payment-method
-summary: Approve payment method
+summary: Buyer approval callback
 description: |-
-  Redirect a buyer to an alternative payment provider to approve their payment
-  method. This is mainly used with providers like PayPal and Klarna to redirect
-  a buyer to their sites.
+  Internal API used as a redirect endpoint for payment methods that require
+  buyer authorization.
+
+  For example, when a buyer tries to add a PayPal payment method, the buyer
+  needs to be sent to PayPal, after which they are sent back to this endpoint
+  upon completion.
+
+  This API applies any required updates for the payment method based on its
+  query parameters and then redirects the browser back to the `redirect_url`
+  specified when the payment method was first created.
 tags:
   - Payment Methods
 x-internal: true
-
 security: []
 
 responses:
   "302":
     description: |-
-      Redirect the buyer to approve this payment method.
+      Redirects the browser back to the `redirect_url` specified
+      when the payment method was first created. It appends the payment method's
+      ID and status.
     headers:
       location:
         description: |-
-          The URL to redirect the browser to. This is the approval URL for an
-          alternative payment method like PayPal.
+          The URL to redirect the browser to. This is the `redirect_url`
+          specified when the payment method was first created with some
+          additional query parameters appended.
+
+          * `payment_method_id` - The ID of the payment method
+          * `payment_method_status` - The current value of the
+            `status`  field of the payment method
 
         schema:
           type: string
           format: url
           example: |-
-            https://paypal.com/...
+            https://example.com/callback?payment_method_id=77a76f7e-d2de-4bbc-ada9-d6a0015e6bd5&payment_method_status=tokenized
 
   "404":
     description: Returns an error if the resource can not be found.

--- a/reference/paths/payment_methods__async-store-payment-method.yaml
+++ b/reference/paths/payment_methods__async-store-payment-method.yaml
@@ -12,8 +12,8 @@ requestBody:
         oneOf:
           - $ref: |-
               ../openapi.yaml#/components/schemas/CardRequest
-          - $ref: |-
-              ../openapi.yaml#/components/schemas/PayPalRequest
+          # - $ref: |-
+          #     ../openapi.yaml#/components/schemas/PayPalRequest
 
 responses:
   "202":

--- a/reference/paths/payment_methods__redirect-payment-method-approval.yaml
+++ b/reference/paths/payment_methods__redirect-payment-method-approval.yaml
@@ -1,0 +1,35 @@
+---
+operationId: redirect-payment-method-approval
+summary: Approve payment method
+description: |-
+  Redirect a buyer to an alternative payment provider to approve their payment
+  method. This is mainly used with providers like PayPal and Klarna to redirect
+  a buyer to their sites.
+tags:
+  - Payment Methods
+x-internal: true
+
+security: []
+
+responses:
+  "302":
+    description: |-
+      Redirect the buyer to approve this payment method.
+    headers:
+      location:
+        description: |-
+          The URL to redirect the browser to. This is the approval URL for an
+          alternative payment method like PayPal.
+
+        schema:
+          type: string
+          format: url
+          example: |-
+            https://paypal.com/...
+
+  "404":
+    description: Returns an error if the resource can not be found.
+    content:
+      application/json:
+        schema:
+          $ref: "../openapi.yaml#/components/schemas/Error404NotFound"

--- a/reference/paths/transactions__approve-transaction.yaml
+++ b/reference/paths/transactions__approve-transaction.yaml
@@ -1,19 +1,19 @@
 ---
-operationId: confirm-payment-method
-summary: Confirm buyer authorization
+operationId: approve-transaction
+summary: Buyer approval callback
 description: |-
-  Internal API used as a redirect endpoint for payment methods that require
+  Internal API used as a redirect endpoint for transactions that require
   buyer authorization.
 
-  For example, when a buyer tries to add a PayPal payment method, the buyer
+  For example, when a buyer tries to create a PayPal transaction, the buyer
   needs to be sent to PayPal, after which they are sent back to this endpoint
   upon completion.
 
-  This API applies any required updates for the payment method based on its
+  This API applies any required updates for the transaction based on its
   query parameters and then redirects the browser back to the `redirect_url`
   specified when the payment method was first created.
 tags:
-  - Payment Methods
+  - Transactions
 x-internal: true
 security: []
 
@@ -21,24 +21,24 @@ responses:
   "302":
     description: |-
       Redirects the browser back to the `redirect_url` specified
-      when the payment method was first created. It appends the payment method's
+      when the transaction was first created. It appends the transaction's
       ID and status.
     headers:
       location:
         description: |-
           The URL to redirect the browser to. This is the `redirect_url`
-          specified when the payment method was first created with some
+          specified when the transaction was first created with some
           additional query parameters appended.
 
-          * `payment_method_id` - The ID of the payment method
-          * `payment_method_status` - The current value of the
-            `status`  field of the payment method
+          * `transaction_id` - The ID of the transaction
+          * `transaction_status` - The current value of the
+            `status`  field of the transaction
 
         schema:
           type: string
           format: url
           example: |-
-            https://example.com/callback?payment_method_id=77a76f7e-d2de-4bbc-ada9-d6a0015e6bd5&payment_method_status=tokenized
+            https://example.com/callback?transaction_id=77a76f7e-d2de-4bbc-ada9-d6a0015e6bd5&transaction_status=tokenized
 
   "404":
     description: Returns an error if the resource can not be found.

--- a/reference/paths/transactions__async-authorize-transaction.yaml
+++ b/reference/paths/transactions__async-authorize-transaction.yaml
@@ -1,0 +1,39 @@
+---
+operationId: async-authorize-transaction
+summary: Authorize approved transaction
+tags: ["Async APIs"]
+description: |-
+  Authorize a previously approved transaction.
+
+  This API returns asynchronously, returning status object with the ID of the
+  pending `Transaction` resource.
+
+responses:
+  "202":
+    description: Accepted
+    content:
+      application/json:
+        schema:
+          $ref: "../openapi.yaml#/components/schemas/Status"
+        examples:
+          Pending transaction:
+            value:
+              type: status
+              status: pending
+              resource_type: transaction
+              resource_id: 8724fd24-5489-4a5d-90fd-0604df7d3b83
+              external_identifier: user-789123
+
+  "400":
+    description: Returns an error if the request was badly formatted.
+    content:
+      application/json:
+        schema:
+          $ref: "../openapi.yaml#/components/schemas/Error400IncorrectJson"
+
+  "401":
+    description: Returns an error if no valid authentication was provided.
+    content:
+      application/json:
+        schema:
+          $ref: "../openapi.yaml#/components/schemas/Error401Unauthorized"

--- a/reference/paths/transactions__async-create-transaction.yaml
+++ b/reference/paths/transactions__async-create-transaction.yaml
@@ -42,7 +42,7 @@ requestBody:
           value:
             amount: 1299
             currency: USD
-            capture: true
+            intent: "capture"
             store: true
             payment_method:
               method: card
@@ -53,7 +53,7 @@ requestBody:
           value:
             amount: 1299
             currency: USD
-            capture: true
+            intent: "capture"
             payment_method:
               method: paypal
               redirect_url: https://example.com/callback
@@ -61,7 +61,7 @@ requestBody:
           value:
             amount: 1299
             currency: USD
-            capture: true
+            intent: "capture"
             payment_method:
               method: token
               token: "0123456789123458"

--- a/reference/paths/transactions__authorize-transaction.yaml
+++ b/reference/paths/transactions__authorize-transaction.yaml
@@ -1,30 +1,17 @@
 ---
-operationId: store-payment-method
-summary: Store a new payment method
-description: Stores and tokenizes a new payment method
+operationId: authorize-transaction
+summary: Authorize approved transaction
+description: Authorize a previously approved transaction.
 tags:
-  - Payment Methods
-
-requestBody:
-  content:
-    application/json:
-      schema:
-        oneOf:
-          - $ref: |-
-              ../openapi.yaml#/components/schemas/CardRequest
-          # - $ref: |-
-          #     ../openapi.yaml#/components/schemas/PayPalRequest
+  - Transactions
 
 responses:
-  "201":
-    description: Created
+  "200":
+    description: A transaction
     content:
       application/json:
         schema:
-          oneOf:
-            - $ref: "../openapi.yaml#/components/schemas/Card"
-            # Disabled for now until we will support PayPal tokenization
-            # - $ref: "../openapi.yaml#/components/schemas/PayPal"
+          $ref: "../openapi.yaml#/components/schemas/Transaction"
 
   "400":
     description:
@@ -45,3 +32,16 @@ responses:
       application/json:
         schema:
           $ref: "../openapi.yaml#/components/schemas/Error401Unauthorized"
+
+  "404":
+    description:
+      Returns an error if the resource can not be found or has not yet been
+      created.
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - $ref: |-
+                ../openapi.yaml#/components/schemas/Error404NotFound
+            - $ref: |-
+                ../openapi.yaml#/components/schemas/Error404PendingCreation

--- a/reference/paths/transactions__create-transaction.yaml
+++ b/reference/paths/transactions__create-transaction.yaml
@@ -45,7 +45,7 @@ requestBody:
           value:
             amount: 1299
             currency: USD
-            capture: true
+            intent: "capture"
             store: true
             payment_method:
               method: card
@@ -56,7 +56,7 @@ requestBody:
           value:
             amount: 1299
             currency: USD
-            capture: true
+            intent: "capture"
             payment_method:
               method: paypal
               redirect_url: https://example.com/callback
@@ -64,7 +64,7 @@ requestBody:
           value:
             amount: 1299
             currency: USD
-            capture: true
+            intent: "capture"
             payment_method:
               method: token
               token: "0123456789123458"

--- a/reference/paths/transactions__redirect-transaction-approval.yaml
+++ b/reference/paths/transactions__redirect-transaction-approval.yaml
@@ -1,0 +1,35 @@
+---
+operationId: redirect-transaction-approval
+summary: Approve payment method
+description: |-
+  Redirect a buyer to an alternative payment provider to approve their
+  transaction. This is mainly used with providers like PayPal and Klarna to
+  redirect a buyer to their sites.
+tags:
+  - Transactions
+x-internal: true
+
+security: []
+
+responses:
+  "302":
+    description: |-
+      Redirect the buyer to approve this transaction.
+    headers:
+      location:
+        description: |-
+          The URL to redirect the browser to. This is the approval URL for an
+          alternative payment method like PayPal.
+
+        schema:
+          type: string
+          format: url
+          example: |-
+            https://paypal.com/...
+
+  "404":
+    description: Returns an error if the resource can not be found.
+    content:
+      application/json:
+        schema:
+          $ref: "../openapi.yaml#/components/schemas/Error404NotFound"

--- a/reference/request-bodies/transaction_create_request.yaml
+++ b/reference/request-bodies/transaction_create_request.yaml
@@ -42,17 +42,30 @@ properties:
     type: boolean
     description: |-
       Whether or not to also try and store the payment method with us so that
-      it can be used again for future use.
+      it can be used again for future use. This is only supported for payment
+      methods that support this feature.
     example: true
     default: false
 
-  capture:
-    type: boolean
-    description:
-      "Whether a successful authorization should immediately be captured as
-      well, effectively processing the payment directly."
-    default: "false"
-    example: true
+  intent:
+    type: string
+    description: |-
+      Defines the intent of this API call. This determines the desired initial
+      state of the transaction.
+
+      * `approve` - Captures approval for the transaction from the user but does
+      not authorize it. This is only available to payment methods that require
+      explicit approval, like PayPal.
+      * `authorize` - (Default) Optionally approves and then authorizes a
+      transaction but does not capture the funds.
+      * `capture` - Optionally approves and then authorizes and captures the
+      funds of the transaction.
+    default: "authorize"
+    example: "capture"
+    enum:
+      - approve
+      - authorize
+      - capture
 
   external_identifier:
     type: string

--- a/reference/resources/paypal.yaml
+++ b/reference/resources/paypal.yaml
@@ -34,6 +34,7 @@ properties:
       - buyer_approval_pending
       - buyer_approval_declined
       - buyer_approval_timedout
+      - buyer_approved
       - stored
 
   token:


### PR DESCRIPTION
- Rename payment method approval/confirm endpoints
- Add transaction approval-redirect/approve endpoints
- Add new approved status to payment methods and transactions
- Add new endpoint to authorize a previously approved resource
- Update payment method/transaction status enums to include new approved status
- Disable tokenizing paypal payment methods (for now)
- Refactor the `capture` enum into an `intent` with possible values `approve`, `authorize`, `capture`.