### PR TITLE
Re-introduce buyer-payment-methods endpoint 

### DIFF
--- a/reference/openapi.yaml
+++ b/reference/openapi.yaml
@@ -32,6 +32,7 @@ tags:
       In Gr4vy, an API key pair is used to sign and validate JWTs. A JWT is used
       as a bearer token to authenticate to the API.
     x-internal: true
+
   - name: Async APIs
     description: |-
       The asynchronous (async) APIs are convenience APIs that function as an
@@ -39,6 +40,7 @@ tags:
       without having to wait for the API to complete. Each of thee APIs returns
       directly without processing the request fully, allowing you to render a
       new page for the buyer while the request is processed.
+
   - name: Buyers
     description: |-
       In Gr4vy, a buyer represents your customer, the shopper who's performing
@@ -59,11 +61,13 @@ tags:
       In Gr4vy, a card rule defines how a card transaction is processed. It
       determines which payment services are used, and with what priority, based
       on the transaction amount, card type, and many more attributes.
+
   - name: Merchants
     description: |-
       In Gr4vy, a merchant represents the entity that owns the Gr4vy cluster.
       Currently only one merchant is supported per cluster.
     x-internal: true
+
   - name: Payment Methods
     description: |-
       In Gr4vy, a payment method represents a way in which a payment can be processed,
@@ -93,6 +97,7 @@ tags:
     description: |-
       Payment service definitions describe the fields required for a payment
       service to be configured.
+
   - name: Payment Services
     description: |-
       In Gr4vy, a payment service represents a configured payment provider
@@ -110,6 +115,7 @@ tags:
       The sessions APIs are used to facilitate user authentication for the Gr4vy
       cluster admin.
     x-internal: true
+
   - name: Transactions
     description: |-
       In Gr4vy, a transaction represents a payment in any state, either before it is
@@ -188,6 +194,10 @@ paths:
       $ref: "./paths/buyers__update-buyer.yaml"
     delete:
       $ref: "./paths/buyers__delete-buyer.yaml"
+
+  "/buyers/payment-methods":
+    get:
+      $ref: "./paths/payment_methods__list-buyer-payment-methods.yaml"
 
   "/merchants/main":
     get:
@@ -379,6 +389,8 @@ components:
       $ref: "./resources/merchant.yaml"
     PaymentMethods:
       $ref: "./resources/payment_methods.yaml"
+    PaymentMethods--Token:
+      $ref: "./resources/payment_methods--token.yaml"
     PaymentMethodEvent:
       $ref: "./resources/payment_method_event.yaml"
     PaymentMethodEvents:

--- a/reference/paths/payment_methods__list-buyer-payment-methods.yaml
+++ b/reference/paths/payment_methods__list-buyer-payment-methods.yaml
@@ -1,0 +1,38 @@
+---
+operationId: list-buyer-payment-methods
+summary: List stored payment methods for a buyer
+description: |-
+  Returns a list of stored, tokenized payment methods for a buyer in
+  a short tokenized format.
+tags:
+  - Payment Methods
+
+parameters:
+  - $ref: "../query-parameters/buyer_id.yaml"
+  - $ref: "../query-parameters/buyer_external_identifier.yaml"
+  - $ref: "../query-parameters/country.yaml"
+  - $ref: "../query-parameters/currency.yaml"
+
+responses:
+  "200":
+    description: |-
+      Returns a list of available payment methods for a buyer, filtered by the
+      the given currency and country code.
+    content:
+      application/json:
+        schema:
+          $ref: "../openapi.yaml#/components/schemas/PaymentMethods--Token"
+
+  "404":
+    description: Returns an error if the resource can not be found.
+    content:
+      application/json:
+        schema:
+          $ref: "../openapi.yaml#/components/schemas/Error404NotFound"
+
+  "401":
+    description: Returns an error if no valid authentication was provided.
+    content:
+      application/json:
+        schema:
+          $ref: "../openapi.yaml#/components/schemas/Error401Unauthorized"

--- a/reference/resources/payment_methods--token.yaml
+++ b/reference/resources/payment_methods--token.yaml
@@ -1,0 +1,25 @@
+---
+title: Payment Methods (Token only)
+type: object
+description: A list of stored payment methods in token format.
+
+x-tags:
+  - Payment Methods
+
+properties:
+  items:
+    type: array
+    description: A list of stored payment methods in token format.
+    items:
+      oneOf:
+        - $ref: "../openapi.yaml#/components/schemas/Card--Token"
+        - $ref: "../openapi.yaml#/components/schemas/PayPal--Token"
+
+  limit:
+    $ref: "../properties/limit-100.yaml"
+
+  next_cursor:
+    $ref: "../properties/next_cursor.yaml"
+
+  previous_cursor:
+    $ref: "../properties/previous_cursor.yaml"

--- a/reference/resources/payment_methods.yaml
+++ b/reference/resources/payment_methods.yaml
@@ -4,7 +4,7 @@ type: object
 description: A list of stored payment methods.
 
 x-tags:
-  - PaymentMethods
+  - Payment Methods
 
 properties:
   items:
@@ -12,8 +12,8 @@ properties:
     description: A list of stored payment methods.
     items:
       oneOf:
-        - $ref: "../openapi.yaml#/components/schemas/Card--Token"
-        - $ref: "../openapi.yaml#/components/schemas/PayPal--Token"
+        - $ref: "../openapi.yaml#/components/schemas/Card"
+        - $ref: "../openapi.yaml#/components/schemas/PayPal"
 
   limit:
     $ref: "../properties/limit-100.yaml"

--- a/reference/resources/transaction.yaml
+++ b/reference/resources/transaction.yaml
@@ -1,7 +1,7 @@
 ---
 title: Transaction
 type: object
-description: Captures a transaction.
+description: A transaction record.
 x-tags:
   - Transactions
 


### PR DESCRIPTION
Adding the `GET /buyers/payment-methods` API. It returns a different shorter format for use in Embed and allows for searching of payment methods by buyer ID. It also allows for filtering by country and currency as well.