### PR TITLE
Return complete payment services in transactions

### DIFF
--- a/reference/paths/transactions__create-transaction.yaml
+++ b/reference/paths/transactions__create-transaction.yaml
@@ -107,8 +107,18 @@ responses:
               created_at: "2013-07-16T19:23:00.000Z"
               external_identifier: user-789123
               updated_at: "2019-08-24T14:15:22Z"
-              payment_service_id: |-
-                stripe-card-169f5226-4644-4d1e-ac36-14999e73601f
+              payment_service:
+                id: stripe-card-169f5226-4644-4d1e-ac36-14999e73601f
+                type: payment-service
+                payment_service_definition_id: stripe-card
+                method: card
+                display_name: Stripe (Main)
+                status: pending
+                accepted_currencies:
+                  - EUR
+                accepted_countries:
+                  - DE
+                use_test_environment: true
           PayPal transaction:
             value:
               type: transaction
@@ -139,8 +149,18 @@ responses:
               created_at: "2013-07-16T19:23:00.000Z"
               external_identifier: user-789123
               updated_at: "2019-08-24T14:15:22Z"
-              payment_service_id: |-
-                stripe-card-169f5226-4644-4d1e-ac36-14999e73601f
+              payment_service:
+                id: stripe-card-169f5226-4644-4d1e-ac36-14999e73601f
+                type: payment-service
+                payment_service_definition_id: stripe-card
+                method: card
+                display_name: Stripe (Main)
+                status: pending
+                accepted_currencies:
+                  - EUR
+                accepted_countries:
+                  - DE
+                use_test_environment: true
 
   "400":
     description:

--- a/reference/resources/transaction.yaml
+++ b/reference/resources/transaction.yaml
@@ -80,8 +80,5 @@ properties:
     format: date-time
     description: "Defines when the transaction was last updated "
 
-  payment_service_id:
-    type: string
-    example: paypal-paypal-169f5226-4644-4d1e-ac36-14999e73601f
-    description:
-      The ID of the payment service that was used for this transaction.
+  payment_service:
+    $ref: "../openapi.yaml#/components/schemas/PaymentService"


### PR DESCRIPTION
Simplify our transaction API to return the actual payment services object used in the transaction, as referenced in the API. We should decide if this service is duplicated into the transaction table or of it's simply a reference to an existing payment service record.