### PR TITLE
Add a build of OpenAPI for SDK generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,3 +164,39 @@ jobs:
           WEBHOOK_URL: ${{ secrets.NETLIFY_WEBHOOK }}
           data: "{}"
 
+  sdks:
+    if: github.ref == 'refs/heads/sdks'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    needs:
+      - lint
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Node dependencies
+        run: |
+          yarn install
+
+      - name: Strip all private APIs
+        run: |
+          yarn build:sdks-spec
+
+      - name: Push compiled content
+        uses: s0/git-publish-subdir-action@develop
+        env:
+          REPO: self
+          BRANCH: docs
+          FOLDER: sdks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 public
 redoc
 public-tmp
+sdks

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -3,6 +3,7 @@ functionsDir: ./spectral/
 functions:
   - full-stop
   - response-description-returns
+  - oneof-model-name
 
 formats: []
 
@@ -33,3 +34,10 @@ rules:
     severity: error
     then:
       function: response-description-returns
+
+  oneof-model-name:
+    description: A oneOf item needs a valid model name
+    given: $..*[?(@.oneOf)]
+    severity: error
+    then:
+      function: oneof-model-name

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prebuild:swagger": "yarn build:openapi",
     "build:swagger": "api-spec-converter --from=openapi_3 --to=swagger_2 --syntax=json build/openapi.v1.json > build/swagger.v1.json",
     "build:public-spec": "rm -rf public-tmp public; cp -r reference public-tmp; node ./scripts/build-public-spec.js;  node ./scripts/build-openapi.js public-tmp public",
+    "build:sdk-spec": "rm -rf sdks; mkdir sdks; yarn build:public-spec; node ./scripts/build-sdk-spec.js",
     "test": "yarn lint"
   },
   "repository": {

--- a/reference/openapi.yaml
+++ b/reference/openapi.yaml
@@ -359,8 +359,8 @@ components:
       $ref: "./request-bodies/card_rule_create_request.yaml"
     CardRuleUpdateRequest:
       $ref: "./request-bodies/card_rule_update_request.yaml"
-    Error:
-      $ref: "./resources/error.yaml"
+    ErrorGeneric:
+      $ref: "./resources/error_generic.yaml"
     Error400BadRequest:
       $ref: "./resources/error_400_bad_request.yaml"
     Error400IncorrectJson:
@@ -381,6 +381,8 @@ components:
       $ref: "./resources/api_key_pairs.yaml"
     Merchant:
       $ref: "./resources/merchant.yaml"
+    PaymentMethod:
+      $ref: "./resources/payment_method.yaml"
     PaymentMethods:
       $ref: "./resources/payment_methods.yaml"
     # PaymentMethodEvent:
@@ -431,6 +433,8 @@ components:
       $ref: "./request-bodies/transaction_create_request.yaml"
     TransactionCaptureRequest:
       $ref: "./request-bodies/transaction_capture_request.yaml"
+    TransactionPaymentMethodRequest:
+      $ref: "./request-bodies/transaction_payment_method_request.yaml"
     # TransactionEvent:
     #   $ref: "./resources/transaction_event.yaml"
     # TransactionEvents:

--- a/reference/paths/async__store-payment-method.yaml
+++ b/reference/paths/async__store-payment-method.yaml
@@ -35,6 +35,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error400BadRequest

--- a/reference/paths/buyers__add-buyer.yaml
+++ b/reference/paths/buyers__add-buyer.yaml
@@ -33,6 +33,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error400BadRequest

--- a/reference/paths/buyers__get-buyer.yaml
+++ b/reference/paths/buyers__get-buyer.yaml
@@ -27,3 +27,10 @@ responses:
       application/json:
         schema:
           $ref: "../openapi.yaml#/components/schemas/Error404NotFound"
+
+  default:
+    description: Returns a generic error.
+    content:
+      application/json:
+        schema:
+          $ref: "../openapi.yaml#/components/schemas/ErrorGeneric"

--- a/reference/paths/buyers__update-buyer.yaml
+++ b/reference/paths/buyers__update-buyer.yaml
@@ -33,6 +33,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error400BadRequest

--- a/reference/paths/card_rules__add-card-rule.yaml
+++ b/reference/paths/card_rules__add-card-rule.yaml
@@ -27,6 +27,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error400BadRequest

--- a/reference/paths/card_rules__delete-card-rule.yaml
+++ b/reference/paths/card_rules__delete-card-rule.yaml
@@ -22,7 +22,7 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "../openapi.yaml#/components/schemas/Error"
+          $ref: "../openapi.yaml#/components/schemas/ErrorGeneric"
         examples:
           Workflow is active:
             value:

--- a/reference/paths/card_rules__update-card-rule.yaml
+++ b/reference/paths/card_rules__update-card-rule.yaml
@@ -27,6 +27,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error400BadRequest

--- a/reference/paths/payment_methods__get-payment-method.yaml
+++ b/reference/paths/payment_methods__get-payment-method.yaml
@@ -11,6 +11,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: PaymentMethod
           oneOf:
             - $ref: "../openapi.yaml#/components/schemas/Card"
             - $ref: "../openapi.yaml#/components/schemas/PayPal"

--- a/reference/paths/payment_methods__store-payment-method.yaml
+++ b/reference/paths/payment_methods__store-payment-method.yaml
@@ -26,6 +26,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error400BadRequest

--- a/reference/paths/payment_services__add-payment-service.yaml
+++ b/reference/paths/payment_services__add-payment-service.yaml
@@ -42,6 +42,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error400BadRequest

--- a/reference/paths/payment_services__update-payment-service.yaml
+++ b/reference/paths/payment_services__update-payment-service.yaml
@@ -27,6 +27,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error400BadRequest

--- a/reference/paths/sessions__login.yaml
+++ b/reference/paths/sessions__login.yaml
@@ -31,6 +31,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error400BadRequest

--- a/reference/paths/sessions__refresh.yaml
+++ b/reference/paths/sessions__refresh.yaml
@@ -23,6 +23,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error400BadRequest

--- a/reference/paths/transactions__authorize-transaction.yaml
+++ b/reference/paths/transactions__authorize-transaction.yaml
@@ -20,6 +20,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error400BadRequest
@@ -40,6 +41,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error404NotFound

--- a/reference/paths/transactions__capture-transaction.yaml
+++ b/reference/paths/transactions__capture-transaction.yaml
@@ -30,6 +30,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error400BadRequest
@@ -50,6 +51,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error404NotFound

--- a/reference/paths/transactions__create-transaction.yaml
+++ b/reference/paths/transactions__create-transaction.yaml
@@ -169,6 +169,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error400BadRequest

--- a/reference/paths/transactions__get-transaction.yaml
+++ b/reference/paths/transactions__get-transaction.yaml
@@ -27,6 +27,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error404NotFound

--- a/reference/paths/transactions__refund-transaction.yaml
+++ b/reference/paths/transactions__refund-transaction.yaml
@@ -30,6 +30,7 @@ responses:
     content:
       application/json:
         schema:
+          x-model-name: ErrorGeneric
           oneOf:
             - $ref: |-
                 ../openapi.yaml#/components/schemas/Error404NotFound

--- a/reference/request-bodies/card_rule_create_request.yaml
+++ b/reference/request-bodies/card_rule_create_request.yaml
@@ -36,6 +36,7 @@ properties:
       needs to match for this rule to go into effect.
     minItems: 1
     items:
+      x-model-name: CardRule
       oneOf:
         - $ref: "../openapi.yaml#/components/schemas/CardRuleTextCondition"
         - $ref: "../openapi.yaml#/components/schemas/CardRuleNumberCondition"

--- a/reference/request-bodies/card_rule_update_request.yaml
+++ b/reference/request-bodies/card_rule_update_request.yaml
@@ -31,6 +31,7 @@ properties:
       needs to match for this rule to go into effect.
     minItems: 1
     items:
+      x-model-name: CardRule
       oneOf:
         - $ref: "../openapi.yaml#/components/schemas/CardRuleTextCondition"
         - $ref: "../openapi.yaml#/components/schemas/CardRuleNumberCondition"

--- a/reference/request-bodies/transaction_create_request.yaml
+++ b/reference/request-bodies/transaction_create_request.yaml
@@ -29,6 +29,7 @@ properties:
     description: A supported ISO-4217 currency code.
 
   payment_method:
+    x-model-name: TransactionPaymentMethodRequest
     oneOf:
       - $ref: "../openapi.yaml#/components/schemas/CardRequest"
       - $ref: "../openapi.yaml#/components/schemas/PayPalRequest"

--- a/reference/request-bodies/transaction_payment_method_request.yaml
+++ b/reference/request-bodies/transaction_payment_method_request.yaml
@@ -1,0 +1,101 @@
+---
+title: Transaction payment method request
+type: object
+description: |-
+  Payment method details to use in a transaction or to register
+  a new payment method.
+
+x-tags:
+  - Request Bodies
+
+required:
+  - method
+
+properties:
+  method:
+    type: string
+    description: The method to use for this request.
+    example: card
+    enum:
+      - card
+      - paypal
+      - token
+
+  number:
+    type: string
+    minLength: 14
+    maxLength: 16
+    example: "4111111111111111"
+    pattern: "^[0-9]{14,16}$"
+    description: |-
+      The 15-16 digit number for this credit card as it can be found on the
+      front of the card.
+
+      If a card has been stored with us previously, this number will represent
+      the unique tokenized card ID provided via our API.
+
+  expiration_date:
+    type: string
+    description: |-
+      The expiration date of the card, formatted `MM/YY`. If a card has been
+      previously stored with us this value is optional.
+
+      If the `number` of this card represents a tokenized card, then this value
+      is ignored.
+    example: 11/15
+    pattern: ^\d\d/\d\d$
+    minLength: 5
+    maxLength: 5
+
+  security_code:
+    type: string
+    description: |-
+      The 3 or 4 digit security code often found on the card. This often
+      referred to as the CVV or CVD.
+
+      If the `number` of this card represents a tokenized card, then this value
+      is ignored.
+    pattern: '^\d{3,4}$'
+    minLength: 3
+    maxLength: 4
+    example: "123"
+
+  external_identifier:
+    type: string
+    description:
+      An external identifier that can be used to match the card against your own
+      records.
+    example: user-789123
+    nullable: true
+
+  buyer_id:
+    type: string
+    format: uuid
+    example: fe26475d-ec3e-4884-9553-f7356683f7f9
+    description: |-
+      The ID of the buyer to associate this payment method to. If this field is
+      provided then the `buyer_external_identifier` field needs to be unset.
+
+  buyer_external_identifier:
+    type: string
+    description: |-
+      The `external_identifier` of the buyer to associate this payment method
+      to. If this field is provided then the `buyer_id` field
+      needs to be unset.
+    example: user-789123
+
+  redirect_url:
+    type: string
+    format: uri
+    description: |-
+      The redirect URL to redirect a buyer to after they have authorized their
+      transaction or payment method. This only applies to payment methods that
+      require buyer approval.
+    example: https://example.com/callback
+
+  token:
+    type: string
+    description: |-
+      A Gr4vy token that represents a previously tokenized payment method.
+      This token can represent any type of payment method.
+    example: "77a76f7e-d2de-4bbc-ada9-d6a0015e6bd5"

--- a/reference/resources/card_rule.yaml
+++ b/reference/resources/card_rule.yaml
@@ -38,6 +38,7 @@ properties:
       needs to match for this rule to go into effect.
     minItems: 1
     items:
+      x-model-name: CardRule
       oneOf:
         - $ref: "../openapi.yaml#/components/schemas/CardRuleTextCondition"
         - $ref: "../openapi.yaml#/components/schemas/CardRuleNumberCondition"

--- a/reference/resources/error_generic.yaml
+++ b/reference/resources/error_generic.yaml
@@ -1,8 +1,7 @@
 ---
-title: Error
+title: Generic Error
 type: object
 description: A generic client error.
-x-internal: true
 
 x-tags:
   - Errors

--- a/reference/resources/payment_method.yaml
+++ b/reference/resources/payment_method.yaml
@@ -1,0 +1,126 @@
+---
+title: Payment method
+description: A generic payment method.
+type: object
+x-tags:
+  - Payment Methods
+
+properties:
+  type:
+    type: string
+    description: "`payment-method`."
+    example: payment-method
+    enum:
+      - payment-method
+
+  id:
+    type: string
+    description: |-
+      The unique ID of the payment method.
+    format: uuid
+    example: 77a76f7e-d2de-4bbc-ada9-d6a0015e6bd5
+
+  status:
+    type: string
+    description: |-
+      The state of the payment method.
+    example: stored
+    enum:
+      - processing
+      - processing_failed
+      - buyer_approval_pending
+      - buyer_approval_declined
+      - buyer_approval_timedout
+      - buyer_approved
+      - stored
+      - used
+
+  method:
+    type: string
+    description: The type of this payment method.
+    example: card
+    enum:
+      - card
+      - paypal
+
+  created_at:
+    type: string
+    description: |-
+      The date and time when this payment method was first created in our
+      system.
+    format: date-time
+    example: "2013-07-16T19:23:00.000+00:00"
+
+  updated_at:
+    type: string
+    description: |-
+      The date and time when this payment method was last updated in our system.
+    format: date-time
+    example: "2013-07-16T19:23:00.000+00:00"
+
+  external_identifier:
+    type: string
+    description: |-
+      An external identifier that can be used to match the payment method
+      against your own records.
+    example: user-789123
+    nullable: true
+
+  buyer:
+    description: |-
+      The optional buyer for which this payment method has been stored.
+    nullable: true
+    allOf:
+      - $ref: "../openapi.yaml#/components/schemas/Buyer"
+
+  details:
+    description: Additional details about a payment method.
+    type: object
+    properties:
+      number:
+        type: string
+        description: |-
+          Partial number details for a stored card, hiding all but the last few
+          numbers.
+        example: XXXX XXXX XXXX 1111
+
+      scheme:
+        type: string
+        example: visa
+        enum:
+          - visa
+          - mastercard
+          - american-express
+          - diners-club
+          - discover
+          - jcb
+          - unionpay
+          - maestro
+          - elo
+          - mir
+          - hiper
+          - hipercard
+        description: |-
+          The type of the card.
+
+      expiration_date:
+        type: string
+        description: |-
+          The expiration date for a card.
+        example: "11 / 21"
+
+      email_address:
+        type: string
+        example: john@example.com
+        description: The email address associated to the payment method.
+        nullable: true
+
+      approval_url:
+        type: string
+        format: uri
+        example: |-
+          https://api.{merchant}.app.gr4vy.com/payment-methods/ffc88ec9-e1ee-45ba-993d-b5902c3b2a8c/approve
+        description:
+          The optional URL that the buyer needs to be redirected to to further
+          authorize the payment method.
+        nullable: true

--- a/reference/resources/payment_methods.yaml
+++ b/reference/resources/payment_methods.yaml
@@ -11,9 +11,7 @@ properties:
     type: array
     description: A list of stored payment methods.
     items:
-      oneOf:
-        - $ref: "../openapi.yaml#/components/schemas/Card--Token"
-        # - $ref: "../openapi.yaml#/components/schemas/PayPal--Token"
+      $ref: "../openapi.yaml#/components/schemas/Card--Token"
 
   limit:
     $ref: "../properties/limit-100.yaml"

--- a/reference/resources/transaction.yaml
+++ b/reference/resources/transaction.yaml
@@ -56,6 +56,7 @@ properties:
     description: The currency code for this transaction.
 
   payment_method:
+    x-model-name: PaymentMethod
     oneOf:
       - $ref: "../openapi.yaml#/components/schemas/Card"
       - $ref: "../openapi.yaml#/components/schemas/PayPal"

--- a/scripts/build-sdk-spec.js
+++ b/scripts/build-sdk-spec.js
@@ -1,0 +1,20 @@
+const fs = require("fs")
+const jp = require("jsonpath")
+
+const OPENAPI = './public/openapi.v1.json'
+
+const spec = JSON.parse(fs.readFileSync(OPENAPI))
+
+const merge = (schema) => ({
+  '$ref': `#/components/schemas/${schema['x-model-name']}`
+})
+
+const removeUriFormat = (schema) => {
+  delete schema['format']
+  return schema
+}
+
+jp.apply(spec, '$..*[?(@.oneOf)]', merge)
+jp.apply(spec, '$..*[?(@.format=="uri")]', removeUriFormat)
+
+fs.writeFileSync('./sdks/openapi.v1.json', JSON.stringify(spec, null, 2))

--- a/spectral/oneof-model-name.js
+++ b/spectral/oneof-model-name.js
@@ -1,0 +1,20 @@
+module.exports = (original, _, __, inventory) => {
+  if (!original['x-model-name']) {
+    return [
+      {
+        message: 'A oneOf relation needs to have a x-model-name attribute to refer to the SDK model to use.',
+      },
+    ]
+  }
+
+  const spec = inventory.documentInventory.resolved
+  const modelName = original['x-model-name']
+  if (modelName && !spec.components.schemas[modelName]) {
+    console.dir(modelName)
+    return [
+      {
+        message: `x-model-name must refer to an actual model (${modelName})`,
+      },
+    ]
+  }
+}


### PR DESCRIPTION
Strips out any usage of `oneOf` and replaces it with generic models