### PR TITLE
add klarna for PHP sdk generation

### DIFF
--- a/reference/request-bodies/transaction_payment_method_request.yaml
+++ b/reference/request-bodies/transaction_payment_method_request.yaml
@@ -19,6 +19,7 @@ properties:
     enum:
       - card
       - paypal
+      - klarna
       - token
 
   number:

--- a/reference/resources/payment_method.yaml
+++ b/reference/resources/payment_method.yaml
@@ -42,6 +42,7 @@ properties:
     enum:
       - card
       - paypal
+      - klarna
 
   created_at:
     type: string

--- a/reference/resources/payment_option.yaml
+++ b/reference/resources/payment_option.yaml
@@ -21,3 +21,4 @@ properties:
     enum:
       - card
       - paypal
+      - klarna

--- a/reference/resources/payment_service.yaml
+++ b/reference/resources/payment_service.yaml
@@ -37,6 +37,7 @@ properties:
     enum:
       - card
       - paypal
+      - klarna
 
   display_name:
     type: string

--- a/reference/resources/payment_service_definition.yaml
+++ b/reference/resources/payment_service_definition.yaml
@@ -32,6 +32,7 @@ properties:
     enum:
       - card
       - paypal
+      - klarna
 
   fields:
     type: array


### PR DESCRIPTION
# Description

The PHP OpenAPI SDK generator is failing because klarna is not a valid enum.

## Checklist

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own changes
- [x ] I have run `yarn test` to make sure my changes pass all linters
- [x ] I have pulled the latest changes from the upstream `main` branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
