### PR TITLE
fix: card rules text value key

### DIFF
--- a/reference/resources/card_rule_text_condition.yaml
+++ b/reference/resources/card_rule_text_condition.yaml
@@ -11,7 +11,7 @@ required:
   - match
   - key
   - operator
-  - values
+  - value
 
 properties:
   match:
@@ -37,7 +37,7 @@ properties:
       - "IN"
       - "NOT IN"
 
-  values:
+  value:
     type: array
     minItems: 1
     maxItems: 100


### PR DESCRIPTION
# Description

Update `value` key for card rules text conditions. Looks like this was missed when the number condition was updated.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
