### PR TITLE
feat: add billing details to buyers

### DIFF
--- a/reference/openapi.yaml
+++ b/reference/openapi.yaml
@@ -354,6 +354,12 @@ paths:
 
 components:
   schemas:
+    Address:
+      $ref: "./resources/address.yaml"
+    TaxID:
+      $ref: "./resources/tax_id.yaml"
+    BillingDetails:
+      $ref: "./resources/billing_details.yaml"
     Buyer:
       $ref: "./resources/buyer.yaml"
     Buyers:

--- a/reference/request-bodies/buyer_create_request.yaml
+++ b/reference/request-bodies/buyer_create_request.yaml
@@ -26,3 +26,9 @@ properties:
     nullable: true
     minLength: 1
     maxLength: 200
+
+  billing_details:
+    description: Billing details associated with the buyer.
+    nullable: true
+    allOf:
+      - $ref: "../openapi.yaml#/components/schemas/BillingDetails"

--- a/reference/resources/address.yaml
+++ b/reference/resources/address.yaml
@@ -1,0 +1,80 @@
+---
+title: Address
+type: object
+x-tags:
+  - Buyers
+
+required:
+  - organization
+  - house_number_or_name
+  - line1
+  - line2
+  - city
+  - state
+  - postal_code
+  - country
+
+properties:
+  organization:
+    type: string
+    description: Organization.
+    nullable: true
+    minLength: 1
+    maxLength: 255
+    example: Gr4vy
+
+  house_number_or_name:
+    type: string
+    description: House number.
+    nullable: true
+    minLength: 1
+    maxLength: 255
+    example: "1"
+
+  line1:
+    type: string
+    description: Address Line 1.
+    nullable: false
+    minLength: 1
+    maxLength: 255
+    example: Buckingham Palace
+
+  line2:
+    type: string
+    description: Address Line 2.
+    nullable: true
+    minLength: 1
+    maxLength: 255
+    example: Spur Road
+
+  city:
+    type: string
+    description: City.
+    nullable: false
+    minLength: 1
+    maxLength: 100
+    example: Westminster
+
+  state:
+    type: string
+    description: State or province.
+    nullable: false
+    minLength: 1
+    maxLength: 255
+    example: London
+
+  postal_code:
+    type: string
+    description: Post/Zip Code.
+    nullable: false
+    minLength: 1
+    maxLength: 50
+    example: SW1A 1AA
+
+  country:
+    type: string
+    description: ISO country code.
+    nullable: false
+    minLength: 2
+    maxLength: 2
+    example: GB

--- a/reference/resources/billing_details.yaml
+++ b/reference/resources/billing_details.yaml
@@ -1,0 +1,50 @@
+---
+title: Buyer details
+type: object
+x-tags:
+  - Buyers
+
+properties:
+  first_name:
+    type: string
+    description: First name of the buyer.
+    example: John
+    nullable: true
+    minLength: 1
+    maxLength: 255
+
+  last_name:
+    type: string
+    description: Last name of the buyer.
+    example: Lunn
+    nullable: true
+    minLength: 1
+    maxLength: 255
+
+  email:
+    type: string
+    description: Email associated with the buyer.
+    example: john@gr4vy.com
+    nullable: true
+    minLength: 1
+    maxLength: 320
+
+  phone_number:
+    type: string
+    description: Phone number associated with the buyer.
+    example: "+13115552368"
+    nullable: true
+    minLength: 1
+    maxLength: 50
+
+  address:
+    description: Address associated with the billing details.
+    nullable: true
+    allOf:
+      - $ref: "../openapi.yaml#/components/schemas/Address"
+
+  tax_id:
+    description: Tax identification number associated with the billing details.
+    nullable: true
+    allOf:
+      - $ref: "../openapi.yaml#/components/schemas/TaxID"

--- a/reference/resources/buyer--snapshot.yaml
+++ b/reference/resources/buyer--snapshot.yaml
@@ -40,3 +40,9 @@ properties:
     nullable: true
     minLength: 1
     maxLength: 200
+
+  billing_details:
+    description: Billing details associated with the buyer.
+    nullable: true
+    allOf:
+      - $ref: "../openapi.yaml#/components/schemas/BillingDetails"

--- a/reference/resources/buyer.yaml
+++ b/reference/resources/buyer.yaml
@@ -38,6 +38,12 @@ properties:
     minLength: 1
     maxLength: 200
 
+  billing_details:
+    description: Billing details associated with the buyer.
+    nullable: true
+    allOf:
+      - $ref: "../openapi.yaml#/components/schemas/BillingDetails"
+
   created_at:
     type: string
     description: |-

--- a/reference/resources/tax_id.yaml
+++ b/reference/resources/tax_id.yaml
@@ -1,0 +1,58 @@
+---
+title: Tax ID
+type: object
+x-tags:
+  - Buyers
+
+required:
+  - kind
+  - value
+
+properties:
+  kind:
+    type: string
+    description: The kind of tax identification reference.
+    example: gb.vat
+    enum:
+      - ae.trn
+      - au.abn
+      - br.cnpj
+      - br.cpf
+      - ca.bn
+      - ca.gst_hst
+      - ca.pst_bc
+      - ca.pst_mb
+      - ca.pst_sk
+      - ca.qst
+      - ch.vat
+      - cl.tin
+      - es.cif
+      - eu.vat
+      - gb.vat
+      - hk.br
+      - id.npwp
+      - in.gst
+      - jp.cn
+      - jp.rn
+      - kr.brn
+      - li.uid
+      - mx.rfc
+      - my.frp
+      - my.itn
+      - my.sst
+      - no.vat
+      - nz.gst
+      - ru.inn
+      - ru.kpp
+      - sa.vat
+      - sg.gst
+      - sg.uen
+      - th.vat
+      - tw.vat
+      - us.ein
+      - za.vat
+
+  value:
+    type: string
+    example: "GB 867935561"
+    description: Tax identification reference itself.


### PR DESCRIPTION
# Description

Adds billing details to `Buyers` to containing name, email, address, and tax id.

Fixes: I189

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
