### PR TITLE
chore: add icon_url to payment service definition api

### DIFF
--- a/reference/resources/payment_service_definition.yaml
+++ b/reference/resources/payment_service_definition.yaml
@@ -94,3 +94,9 @@ properties:
       - US
       - GB
       - DE
+
+  icon_url:
+    type: string
+    nullable: true
+    description: An icon to display for the payment service.
+    example: https://cdn.gr4vy.app/stripe.svg


### PR DESCRIPTION
# Description

Adds `icon_url` to payment service definition object.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn test` to make sure my changes pass all linters
- [x] I have pulled the latest changes from the upstream `main` branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
